### PR TITLE
Config option to disable search field autofocus

### DIFF
--- a/src/main/java/com/zerofall/ezstorage/configuration/EZConfiguration.java
+++ b/src/main/java/com/zerofall/ezstorage/configuration/EZConfiguration.java
@@ -28,6 +28,10 @@ public class EZConfiguration {
     @Config.RangeInt(min = 0)
     public static int maxItemTypes;
 
+    @Config.Comment("Focus the input field when opening a storage GUI.")
+    @Config.DefaultBoolean(true)
+    public static boolean focusGuiInput;
+
     public static void init() {
         try {
             ConfigurationManager.registerConfig(EZConfiguration.class);

--- a/src/main/java/com/zerofall/ezstorage/gui/GuiStorageCore.java
+++ b/src/main/java/com/zerofall/ezstorage/gui/GuiStorageCore.java
@@ -22,6 +22,7 @@ import org.lwjgl.opengl.GL11;
 
 import com.zerofall.ezstorage.EZStorage;
 import com.zerofall.ezstorage.Reference;
+import com.zerofall.ezstorage.configuration.EZConfiguration;
 import com.zerofall.ezstorage.container.ContainerStorageCore;
 import com.zerofall.ezstorage.integration.ModIds;
 import com.zerofall.ezstorage.network.client.MsgInvSlotClicked;
@@ -63,7 +64,7 @@ public class GuiStorageCore extends GuiContainer {
         this.searchField.setEnableBackgroundDrawing(false);
         this.searchField.setTextColor(0xFFFFFF);
         this.searchField.setCanLoseFocus(true);
-        this.searchField.setFocused(true);
+        this.searchField.setFocused(EZConfiguration.focusGuiInput);
         this.searchField.setText(searchText);
     }
 


### PR DESCRIPTION
Does what it says on the tin, adds a toggle to disable the search automatically taking focus when opening a storage GUI.