### PR TITLE
Allow AE2 storage bus to connect to the inv proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple storage mod for Minecraft 1.7.10 (Forge).
 ## Description
 
 Simple Storage (former EZStorage) introduces an early-game storage system that scales and evolves as players progress, while keeping the vanilla flair. Want to put 100k Cobblestone in 1 slot? No problem. The blocks in the mod can add a crafting grid, additional storage, and more. Also includes integration into some mods for easier crafting or additional features!
- 
+
 ## Blocks & Items
 
 - **Storage Core**
@@ -20,7 +20,7 @@ Simple Storage (former EZStorage) introduces an early-game storage system that s
 - **Hyper Storage Box**
   - Tier 3 storage add-on
 - **Proxy Port**
-  - Expose the storage inventory to hoppers, conduits or maschines
+  - Expose the storage inventory to hoppers, conduits, machines and AE2 storage bus
 - **Crafting Box**
   - This adds a crafting grid to the GUI of your Storage Core (compatible with NEI + clicking for easy crafting from the internal inventory)
 - **Portable Storage Panel**
@@ -43,6 +43,8 @@ Simple Storage (former EZStorage) introduces an early-game storage system that s
   - Show typical crafting tweaks buttons on crafting grid
 - **Et Futurum Requiem**
   - Spectator mode
+- **Applied Energistics 2**
+  - Inventory proxy can be used with AE storage buses
 
 ## Remarks
 
@@ -65,3 +67,7 @@ This fork becomes some changes to be usable on servers, less-buggy and a lot of 
 - Replaced input and output block with a more enhanced proxy block
 - Configurable maximum different item types per storage (no limit by default)
 - Store storage as separated file in the world's save directory instead directly on the TileEntity (only send to client when needed)
+
+## Development
+
+With vscode you need to run `gradlew eclipse` for the project to correctly recognize the class paths

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,6 +39,7 @@ dependencies {
     devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.22:dev") {transitive = false}
     devOnlyNonPublishable("com.github.GTNewHorizons:WAILAPlugins:0.7.2:dev") {transitive = false}
     devOnlyNonPublishable("com.github.GTNewHorizons:Jabba:1.5.18:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-791-GTNH:dev") { transitive = false }
     devOnlyNonPublishable(rfg.deobf("curse.maven:et-futurum-requiem-441392:5873837")) { transitive = false }
     devOnlyNonPublishable(rfg.deobf("curse.maven:crafting-tweaks-233071:2457094")) { transitive = false }
     devOnlyNonPublishable(project.files("libs/BaublesExpanded-2.0.3-dev.jar"))

--- a/src/main/java/com/zerofall/ezstorage/integration/IntegrationUtils.java
+++ b/src/main/java/com/zerofall/ezstorage/integration/IntegrationUtils.java
@@ -2,6 +2,7 @@ package com.zerofall.ezstorage.integration;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import com.zerofall.ezstorage.integration.ae2.AE2Integration;
 import com.zerofall.ezstorage.integration.craftingtweaks.CraftingTweaksUtils;
 import com.zerofall.ezstorage.integration.etfuturum.EtFuturumUtils;
 import com.zerofall.ezstorage.nei.NeiHandler;
@@ -17,6 +18,10 @@ public class IntegrationUtils {
     public static void initClient() {
         if (ModIds.NEI.isLoaded()) {
             NeiHandler.init();
+        }
+
+        if (ModIds.APPLIEDENERGISTICS2.isLoaded()) {
+            AE2Integration.register();
         }
     }
 

--- a/src/main/java/com/zerofall/ezstorage/integration/ModIds.java
+++ b/src/main/java/com/zerofall/ezstorage/integration/ModIds.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.common.Loader;
 
 public enum ModIds {
 
+    APPLIEDENERGISTICS2("appliedenergistics2"),
     CRAFTINGTWEAKS("craftingtweaks"),
     NEI("NotEnoughItems"),
     ETFUTURUM("etfuturum"),

--- a/src/main/java/com/zerofall/ezstorage/integration/ae2/AE2Integration.java
+++ b/src/main/java/com/zerofall/ezstorage/integration/ae2/AE2Integration.java
@@ -1,0 +1,15 @@
+package com.zerofall.ezstorage.integration.ae2;
+
+import appeng.api.AEApi;
+import appeng.api.storage.IExternalStorageHandler;
+
+public class AE2Integration {
+
+    public static void register() {
+        IExternalStorageHandler handler = (IExternalStorageHandler) new AE2StorageHandler();
+        AEApi.instance()
+            .registries()
+            .externalStorage()
+            .addExternalStorageInterface(handler);
+    }
+}

--- a/src/main/java/com/zerofall/ezstorage/integration/ae2/AE2StorageHandler.java
+++ b/src/main/java/com/zerofall/ezstorage/integration/ae2/AE2StorageHandler.java
@@ -1,0 +1,34 @@
+package com.zerofall.ezstorage.integration.ae2;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.zerofall.ezstorage.tileentity.TileEntityInventoryProxy;
+
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.IExternalStorageHandler;
+import appeng.api.storage.IMEInventory;
+import appeng.api.storage.StorageChannel;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.me.storage.MEMonitorIInventory;
+
+public class AE2StorageHandler implements IExternalStorageHandler {
+
+    @Override
+    public boolean canHandle(TileEntity te, ForgeDirection d, StorageChannel channel, BaseActionSource mySrc) {
+        return te instanceof TileEntityInventoryProxy && channel == StorageChannel.ITEMS;
+    }
+
+    @Override
+    public IMEInventory<IAEItemStack> getInventory(TileEntity te, ForgeDirection d, StorageChannel channel,
+        BaseActionSource src) {
+        if (channel != StorageChannel.ITEMS) {
+            return null;
+        }
+        if (te instanceof TileEntityInventoryProxy teInvProxy) {
+            return new MEMonitorIInventory(new EZStorageMEAdapter(teInvProxy));
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/zerofall/ezstorage/integration/ae2/EZStorageMEAdapter.java
+++ b/src/main/java/com/zerofall/ezstorage/integration/ae2/EZStorageMEAdapter.java
@@ -1,0 +1,113 @@
+package com.zerofall.ezstorage.integration.ae2;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import net.minecraft.item.ItemStack;
+
+import com.zerofall.ezstorage.tileentity.TileEntityInventoryProxy;
+
+import appeng.api.config.FuzzyMode;
+import appeng.util.InventoryAdaptor;
+import appeng.util.inv.IInventoryDestination;
+import appeng.util.inv.ItemSlot;
+
+public class EZStorageMEAdapter extends InventoryAdaptor {
+
+    private final TileEntityInventoryProxy teInvProxy;
+
+    public EZStorageMEAdapter(TileEntityInventoryProxy teInvProxy) {
+        this.teInvProxy = teInvProxy;
+    }
+
+    @Override
+    public Iterator<ItemSlot> iterator() {
+
+        return new Iterator<ItemSlot>() {
+
+            private int index = 0;
+            private List<ItemStack> inventory = teInvProxy.getInventory().inventory;
+
+            @Override
+            public boolean hasNext() {
+                return index < inventory.size() && inventory.get(index) != null;
+            }
+
+            @Override
+            public ItemSlot next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                ItemStack itemStack = inventory.get(index);
+                ItemSlot itemSlot = new ItemSlot();
+                itemSlot.setItemStack(itemStack);
+                itemSlot.setSlot(index);
+                itemSlot.setExtractable(true);
+                index++;
+                return itemSlot;
+            }
+        };
+    }
+
+    @Override
+    public ItemStack removeItems(int amount, ItemStack filter, IInventoryDestination destination) {
+        int index = teInvProxy.getInventory()
+            .getIndexOf(filter);
+        if (index == -1) {
+            return null;
+        }
+        ItemStack extracted = teInvProxy.getInventory()
+            .getItemStackAt(index, amount);
+
+        return extracted;
+    }
+
+    @Override
+    public ItemStack simulateRemove(int amount, ItemStack filter, IInventoryDestination destination) {
+        int index = teInvProxy.getInventory()
+            .getIndexOf(filter);
+        if (index == -1) {
+            return null;
+        }
+        ItemStack extracted = teInvProxy.getInventory()
+            .simulateRemove(index, amount);
+        return extracted;
+    }
+
+    @Override
+    public ItemStack removeSimilarItems(int amount, ItemStack filter, FuzzyMode fuzzyMode,
+        IInventoryDestination destination) {
+        return null;
+    }
+
+    @Override
+    public ItemStack simulateSimilarRemove(int amount, ItemStack filter, FuzzyMode fuzzyMode,
+        IInventoryDestination destination) {
+        return null;
+    }
+
+    @Override
+    public ItemStack addItems(ItemStack toBeAdded) {
+        ItemStack remainder = teInvProxy.getInventory()
+            .input(toBeAdded);
+        return remainder;
+    }
+
+    @Override
+    public ItemStack simulateAdd(ItemStack toBeSimulated) {
+        ItemStack remainder = teInvProxy.getInventory()
+            .simulateInput(toBeSimulated);
+        return remainder;
+    }
+
+    @Override
+    public boolean containsItems() {
+        for (ItemStack itemStack : teInvProxy.getInventory().inventory) {
+            if (itemStack != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/zerofall/ezstorage/tileentity/TileEntityStorageCore.java
+++ b/src/main/java/com/zerofall/ezstorage/tileentity/TileEntityStorageCore.java
@@ -145,7 +145,7 @@ public class TileEntityStorageCore extends TileEntity {
 
     /**
      * Recursive function that scans a block's neighbors, and adds valid blocks to the multiblock list
-     * 
+     *
      * @param br
      */
     private void getValidNeighbors(BlockRef br, EntityLivingBase entity) {

--- a/src/main/java/com/zerofall/ezstorage/util/EZInventory.java
+++ b/src/main/java/com/zerofall/ezstorage/util/EZInventory.java
@@ -49,6 +49,20 @@ public class EZInventory {
         return stack;
     }
 
+    public ItemStack simulateInput(ItemStack itemStack) {
+        if (getTotalCount() >= maxItems) {
+            return itemStack;
+        }
+        long space = maxItems - getTotalCount();
+        int amount = (int) Math.min(space, (long) itemStack.stackSize);
+        ItemStack remainder = itemStack.copy();
+        remainder.stackSize -= amount;
+        if (remainder.stackSize <= 0) {
+            return null;
+        }
+        return remainder;
+    }
+
     public void sort() {
         Collections.sort(this.inventory, new ItemStackCountComparator());
         setHasChanges();
@@ -124,6 +138,19 @@ public class EZInventory {
             inventory.remove(index);
         }
         setHasChanges();
+        return stack;
+    }
+
+    public ItemStack simulateRemove(int index, int size) {
+        if (index >= inventory.size()) {
+            return null;
+        }
+        ItemStack group = inventory.get(index);
+        ItemStack stack = group.copy();
+        if (size > group.stackSize) {
+            size = group.stackSize;
+        }
+        stack.stackSize = size;
         return stack;
     }
 


### PR DESCRIPTION
Allow the inventory proxy to be connected to a storage bus

This way you could use the storage core into late game, as a glorified ME drive I you want to

--

For context, my storage is huge in my playthrough and now that I'm unlocking AE, I would like to set the storage as a "extract only" storage bus so I can transition smoothly