### PR TITLE
(dupe) Fix getting any items with AE2 crafting terminal

### DIFF
--- a/src/main/java/com/zerofall/ezstorage/util/EZInventory.java
+++ b/src/main/java/com/zerofall/ezstorage/util/EZInventory.java
@@ -176,18 +176,12 @@ public class EZInventory {
     }
 
     public int getIndexOf(ItemStack itemStack) {
-        int index = inventory.indexOf(itemStack);
-
-        if (index == -1) {
-            for (ItemStack inventoryStack : inventory) {
-                index += 1;
-                if (stacksEqual(itemStack, inventoryStack)) {
-                    return index;
-                }
+        for (int i = 0; i < inventory.size(); i++) {
+            if (stacksEqual(inventory.get(i), itemStack)) {
+                return i;
             }
         }
-
-        return index;
+        return -1;
     }
 
     public int slotCount() {


### PR DESCRIPTION
The old code would return inventory.size() - 1 if nothing ever matched, which would bypass the removeItems/simulateRemove in the EZStorageMEAdapter

Before:
Go inside a ME crafting terminal with a storage bus connected to a proxy, try to load a recipe that you can't craft with Shift,  items appear in the crafting grid when they should not. Now you can craft for free, or cancel the craft and keep the items

After: Behaves as expected 